### PR TITLE
Shrink docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 target
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM rustlang/rust:nightly
+FROM rustlang/rust:nightly-buster-slim AS builder
 
-RUN apt-get -y update
-RUN apt-get -y install cmake
+RUN apt-get update && apt-get -y install cmake && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /work
 ADD . .
-
-RUN ln -s /work/data /data
 
 # E.g. "RUSTFLAGS=-C target-cpu=native" for optimizing build for host CPU.
 ARG RUSTFLAGS
@@ -14,10 +11,16 @@ ENV RUSTFLAGS=${RUSTFLAGS:-}
 
 RUN cargo install --path dars
 
-EXPOSE 8001
+FROM debian:stable-20220418-slim
+WORKDIR /work/
+COPY --from=builder /usr/local/cargo/bin/dars /usr/bin/dars
+ADD data /data
 
+ARG DARS_PORT
+ENV DARS_PORT=${DARS_PORT:-8001}
+EXPOSE ${DARS_PORT}
 ENV RUST_LOG=info
 
 ENTRYPOINT [ "dars" ]
-CMD [ "-a", "0.0.0.0:80", "/data/" ]
-
+# TODO: MAke entrypoint shell script to expose DARS_PORT
+CMD [ "-a", "0.0.0.0:8001", "/data/" ]


### PR DESCRIPTION
Decreases the size of the docker image from 3.22 GB to 161 MB