### PR TITLE
Add docker publish step

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,35 @@
+---
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: gauteh/dars
+          tags: semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
       matrix:
         include:
           - {ubuntu: 20.04, rust: nightly}
-          - {ubuntu: 20.04, rust: nightly}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Requires the secrets DOCKER_USERNAME and DOCKER_PASSWORD to be added to the CD environment. Copied from https://docs.github.com/en/actions/publishing-packages/publishing-docker-images?learn=continuous_deployment.

Deployments are done through the github gui where a new tag can be added when you publish the package

Resolves #21 